### PR TITLE
Refactor and performance optimization

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,23 +133,40 @@
                     state += 100000
                 })
 
-                requestIdleCallback(() => {
-                    let reactiveChunk = () => {
-                        if (
-                            window.scrollY >
-                            document.body.scrollHeight - window.innerHeight * 3
-                        )
-                            requestAnimationFrame(() => {
-                                judgeReactivity(
-                                    append(generateChunk(state)),
-                                    reactiveChunk
-                                )
-                                state += 100000
-                            })
-                    }
+                if(typeof requestIdleCallback !== "undefined")
+                    return requestIdleCallback(() => {
+                        let reactiveChunk = () => {
+                            if (
+                                window.scrollY >
+                                document.body.scrollHeight - window.innerHeight * 3
+                            )
+                                requestAnimationFrame(() => {
+                                    judgeReactivity(
+                                        append(generateChunk(state)),
+                                        reactiveChunk
+                                    )
+                                    state += 100000
+                                })
+                        }
 
-                    window.addEventListener('scroll', reactiveChunk, true)
-                })
+                        window.addEventListener('scroll', reactiveChunk, true)
+                    })
+
+                let reactiveChunk = () => {
+                    if (
+                        window.scrollY >
+                        document.body.scrollHeight - window.innerHeight * 3
+                    )
+                        requestAnimationFrame(() => {
+                            judgeReactivity(
+                                append(generateChunk(state)),
+                                reactiveChunk
+                            )
+                            state += 100000
+                        })
+                }
+
+                window.addEventListener('scroll', reactiveChunk, true)
             })
         </script>
     </head>


### PR DESCRIPTION
Extracting 100 century as 1 chunk.
Then display only a chunk which is need.

This lead to significantly better performance. Reducing a first load from 52MB to 2.3KB (if minify) or 1KB if gzipped.

Also I implemented dark mode, and responsiveness. Each line has 100 equal dots if using `Century Gothic` and `minimum screen width is 568px`.

![Hikari](https://pa1.narvii.com/6727/70ba881241bdb3fd32bf918a3773d753f3e9f7ad_hq.gif)
